### PR TITLE
Remove ExecutionMode LocalSizeHint

### DIFF
--- a/execution-env.md
+++ b/execution-env.md
@@ -233,8 +233,6 @@ All execution modes declared by **OpExecutionMode** must be one of the following
 *   **DepthGreater**
 *   **DepthLess**
 *   **DepthUnchanged**
-*   **LocalSize**
-*   **LocalSizeHint**
 
 [//]: # (No subgroups support. Useful, but not widely available?)
 

--- a/execution-env.md
+++ b/execution-env.md
@@ -233,6 +233,7 @@ All execution modes declared by **OpExecutionMode** must be one of the following
 *   **DepthGreater**
 *   **DepthLess**
 *   **DepthUnchanged**
+*   **LocalSize**
 
 [//]: # (No subgroups support. Useful, but not widely available?)
 


### PR DESCRIPTION
This is only allowed in Kernel shaders, which are not allowed in
WebGPU.

Fixes #17