### PR TITLE
ControlBarrier and MemoryBarrier use AcquireRelease

### DIFF
--- a/execution-env.md
+++ b/execution-env.md
@@ -401,9 +401,7 @@ Each block **_B_** in a function must satisfy one of the following rules:
 Among mask bits up to and including 0x10 (SequentiallyConsistent), only the following may be set
 for an **OpControlBarrier** or **OpMemoryBarrier** instruction:
 
-*   **Acquire**
-*   **Release**
-*   **AcquireRelease**  [how does this interact with the memory model?]
+*   **AcquireRelease**
 
 No mask bits up to and including 0x10 (SequentiallyConsistent) may be set for an atomic instruction (**OpAtomic**\*).
 That is, atomic operations use **Relaxed** ordering.


### PR DESCRIPTION
See https://github.com/gpuweb/gpuweb/issues/232#issuecomment-483796355

However, at that meeting didn't really talk much about OpMemoryBarrier,
a.k.a. fences.